### PR TITLE
Add WebCrypto polyfill fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "crypto-sha": "^2.1.1",
     "fast-mod-exp": "^1.0.1",
     "int32-encoding": "^1.0.1",
+    "isomorphic-webcrypto": "^2.3.8",
     "tiny-encryptor": "^1.0.1",
     "uint8-concat": "^1.0.1",
     "uint8-encoding": "^2.0.1"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import "./webcrypto-polyfill";
 
 /* IMPORT */
 

--- a/src/webcrypto-polyfill.ts
+++ b/src/webcrypto-polyfill.ts
@@ -1,0 +1,8 @@
+import WebCrypto from 'isomorphic-webcrypto';
+
+if (typeof globalThis.crypto === 'undefined' || !globalThis.crypto?.subtle) {
+  (globalThis as any).crypto = WebCrypto as unknown as Crypto;
+}
+
+export default globalThis.crypto as Crypto;
+

--- a/test/fallback.js
+++ b/test/fallback.js
@@ -1,0 +1,16 @@
+import {describe} from 'fava';
+
+describe('Fallback crypto', it => {
+  it('works when crypto.subtle is missing', async t => {
+    const original = globalThis.crypto;
+    // Remove crypto to simulate absence
+    delete globalThis.crypto;
+    const Puzzle = (await import('../dist/index.js?no-subtle')).default;
+    const puzzle = await Puzzle.generate({duration:100, message:'x'});
+    const solution = await Puzzle.solve(puzzle);
+    t.is(solution, 'x');
+    // Restore
+    if (original) globalThis.crypto = original;
+  });
+});
+


### PR DESCRIPTION
## Summary
- add `isomorphic-webcrypto` runtime polyfill
- invoke polyfill before importing crypto-dependent modules
- add regression test simulating missing `crypto.subtle`

## Testing
- `npm run compile`
- `npm test` *(fails: Expected "false" to be true)*

------
https://chatgpt.com/codex/tasks/task_e_684d6a2e75d48325925a5e5286958480